### PR TITLE
Improved Mobile Responsiveness By Updating Menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,14 +1,24 @@
-import React, { Component } from "react";
+import React, { Component, useEffect, useState } from "react"
 import { Link } from "react-router-dom";
 
-export default class Header extends Component {
-  constructor() {
-    super();
-    this.state = {
-      toggle: true,
-    };
-  }
-  render() {
+let appbar = {
+  logo: "/assets/logo/urban-greens-logo.png",
+}
+;
+
+export default function Header() {
+  const [isActive, setIsActive] = useState(true);
+  const onClick = () => setIsActive((isActive) => !isActive);
+  useEffect(() => {
+    const handelResize = () => {
+    if (window.innerWidth >= 700) {
+      setIsActive(true);
+    } else {
+      setIsActive(false);
+    }
+  };
+    window.addEventListener("resize", handelResize);
+  });
     return (
       <nav className="appbarBackground">
         <div className="appbarContainer">
@@ -18,32 +28,14 @@ export default class Header extends Component {
                 <img src={appbar.logo} alt="" width="86px" height="86px" />
               </Link>
             </div>
-            <div
-              className="text-2xl sm:hidden"
-              onClick={() => {
-                this.setState({
-                  toggle: !this.state.toggle,
-                });
-              }}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-6 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                onClick={() => {
-                  this.setState({
-                    toggle: !this.state.toggle,
-                  });
-                }}
-              >
+            <div className="text-2xl sm:hidden" onClick={onClick}>
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
               </svg>
             </div>
           </div>
           <div id="mobileMenu">
-            {this.state.toggle ? (
+            {isActive ? (
               <div className="appbarMenuLinks">
                 <div className="navLinks">
                   <Link to="/products" className="">
@@ -66,8 +58,5 @@ export default class Header extends Component {
       </nav>
     );
   }
-}
 
-let appbar = {
-  logo: "/assets/logo/urban-greens-logo.png",
-};
+


### PR DESCRIPTION
By hiding the appbar links on mobile phones and having them always
showing the view after a cetrian viewport.

I also changed it to a functional component to take advantage of react
hooks.

Formatted the code with prettier.